### PR TITLE
再確認

### DIFF
--- a/_ja/tour/tour-of-scala.md
+++ b/_ja/tour/tour-of-scala.md
@@ -33,12 +33,12 @@ Scalaは[全ての値がオブジェクトである](unified-types.html) とい�
 
 ## Scalaは関数型 ##
 Scalaは[すべての関数が値である](unified-types.html) という意味で関数型言語でもあります。
-Scalaは無名関数を定義するために[軽量な構文](basics.html#functions)を提供し、
+Scalaは無名関数を定義するために[軽量な構文](basics.html#関数)を提供し、
 [高階関数](higher-order-functions.html) をサポートし、関数の[ネスト](nested-functions.html) を許可し、[カリー化](multiple-parameter-lists.html) をサポートします。  
 Scalaの[ケースクラス](case-classes.html)と[パターンマッチング](pattern-matching.html)が組み込まれていることにより、多くの関数型プログラミング言語で使われる代数型を作ることができます。
 [シングルトンオブジェクト](singleton-objects.html) はクラスのメンバーではない関数をグループ化する便利な方法を提供します。
 
-さらに、Scalaのパターンマッチングの概念は、[エクストラクタオブジェクト](extractor-objects.html) による一般的な拡張として、[右無視シーケンスパターン](regular-expression-patterns.html)の働きにより、自然に[XMLデータの処理](https://github.com/scala/scala-xml/wiki/XML-Processing) にまで拡張されています。  
+さらに、Scalaのパターンマッチングの概念は、[抽出子オブジェクト](extractor-objects.html) による一般的な拡張として、[右無視シーケンスパターン](regular-expression-patterns.html)の働きにより、自然に[XMLデータの処理](https://github.com/scala/scala-xml/wiki/XML-Processing) にまで拡張されています。  
 （訳者註：現在のバージョンでは右無視シーケンスパターンの説明は正規表現のページから除かれています。[→古いバージョン](https://www.scala-lang.org/old/node/122)）  
 この文脈では、For内包表記はクエリの設計に役立ちます。
 これらの機能により、ScalaはWebサービスのようなアプリケーション開発に理想的なものとなっています。
@@ -62,7 +62,7 @@ Scalaは抽象化が安全で首尾一貫した方法で使われることをコ
 ## Scalaは拡張可能 ##
 
 実際に、ドメイン固有のアプリケーションの開発ではよくドメイン固有の言語拡張が必要となります。
-Scalaはライブラリの形で新しい言語構成をスムーズに追加すことを簡単にする言語メカニズムのユニークな組み合わせを提供します。
+Scalaは言語メカニズムのユニークな組み合わせを提供します。それはライブラリの形での円滑な新しい言語構成の追加を簡単にします。
 
 多くのケースで、これはマクロのようなメタプログラミングの機能を使わずに実現できます。例えば、
 
@@ -76,9 +76,9 @@ Scalaは一般的なJava実行環境 (JRE) と相互運用するように設計�
 特に、主流であるオブジェクト指向のJavaプログラミング言語とのやり取りはできるだけスムーズになっています。
 ScalaではSAMs、[ラムダ](higher-order-functions.html) 、[アノテーション](annotations.html) 、[ジェネリクス](generic-classes.html) のようなJavaの新しい機能には直接の類似物があります。
 
-[デフォルト引数値](default-parameter-values.html) 、[名前付きパラメータ](named-arguments.html) 
+[デフォルト引数](default-parameter-values.html) 、[名前付きパラメータ](named-arguments.html)
 といった、Javaに類似物がないScalaの機能はできるだけ適切でJavaに近い形にコンパイルされます。
-ScalaはJavaのような同じコンパイルモデル(分割コンパイル、動的クラス読み込み) を持っており、数千の既存の高品質なライブラリへのアクセスができます。
+ScalaはJavaのような同じコンパイルモデル(分割コンパイル、動的クラス読み込み) を持っており、数千の既存の高品質なライブラリにアクセスができます。
 
 ## ツアーを楽しんで!
 


### PR DESCRIPTION
- アンカーリンク修正
- エクストラクタオブジェクトを抽出子オブジェクトに変更
- 関係代名詞を使った長めの文章を分割
- デフォルト引数値をデフォルト引数に変更